### PR TITLE
Fix line endings in nmeaoutput.py

### DIFF
--- a/nmeaoutput.py
+++ b/nmeaoutput.py
@@ -71,7 +71,7 @@ def gen_gga(time_t, lat, lng, fix_quality, num_sats, hdop, alt_m, geoidal_sep_m,
     result = 'GPGGA,%s,%s,%s,%s,%s,%d,%02d,%.1f,%.1f,M,%.1f,M,%s' % (hhmmssss, lat_format, lat_pole_prime, lng_format, lng_pole_prime, fix_quality, num_sats, hdop, alt_m, geoidal_sep_m, dgps_format)
     crc = checksum(result)
 
-    return '$%s*%0.2X' % (result, crc)
+    return '$%s*%0.2X\r\n' % (result, crc)
 
 
 def send_udp(sock, ip, port, message):

--- a/nmeaoutput.py
+++ b/nmeaoutput.py
@@ -154,7 +154,7 @@ def main():
             if sock:
                 send_udp(sock, args.ip, args.port, sentence)
             if ser:
-                ser.write(sentence + "\n")
+                ser.write(sentence)
             if virtualPort:
                 #Add \ to make the simbol $ writable
                 dollar_sentence = '\\' + sentence


### PR DESCRIPTION
According to the NMEA-0183 standard, sentences should be terminated
with \r\n. Some programs which parse NMEA strings expect this, and
fail to parse if it is not present.